### PR TITLE
Bundle external dependencies

### DIFF
--- a/build_bundle.ts
+++ b/build_bundle.ts
@@ -17,9 +17,7 @@ await esbuild.build({
   sourcemap: false,
   logLevel: "error",
   minify: true,
-  external: [
-    "https://deno.land/std@*",
-  ],
+  external: [],
   plugins: denoPlugins({
     configPath: new URL("./deno.json", import.meta.url).pathname,
   }),


### PR DESCRIPTION
Silverbullet currently tries to download dependencies at runtime. I'm not sure what the intended reason is, but when deploying in immutable containers or on NixOS, this becomes a problem. I'm not experienced with deno so please let me know if I'm missing anything. If at all possible, it would be nice to see a minor version bump with pre-built files having this fix.